### PR TITLE
Disable radio buttons with keyboard presses

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -234,6 +234,7 @@ function gameStart() {
                 for (i = 0; i < alphabet.length; i++) {
                     if (event.key === alphabet[i] || event.key === alphabet[i].toUpperCase()) {
                         addLetter(rowBlockEl, alphabet[i]);
+                        disableLevelChanges();
                     }
                 }
                 if (event.key === 'Enter') {


### PR DESCRIPTION
Quick, easy change to make it so that the radio buttons are disabled when using the keyboard to type as well